### PR TITLE
revert skipping test module release

### DIFF
--- a/aggregation-log-filter-test/pom.xml
+++ b/aggregation-log-filter-test/pom.xml
@@ -15,24 +15,4 @@
     <name>Aggregation Log Filter Test</name>
     <description>Utilities used in aggregation-log-filter adapters tests</description>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <configuration>
-                    <skipStaging>true</skipStaging>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>


### PR DESCRIPTION
I can't find a way how to skip test module deployment, sonatype website is down. We already have the old version (1.0.3) of test in central repository, so let's publish the new one, too.