### PR TITLE
Log4j2 version increased

### DIFF
--- a/aggregation-log-filter-log4j2/pom.xml
+++ b/aggregation-log-filter-log4j2/pom.xml
@@ -40,7 +40,7 @@
     </description>
 
     <properties>
-        <log4j2.version>2.5</log4j2.version>
+        <log4j2.version>2.13.0</log4j2.version>
     </properties>
 
 


### PR DESCRIPTION
There was a vulnerability found in old version of log4j2, so let's increase the version to current one.